### PR TITLE
kubernetes-debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ dmizverev@yandex.ru
 [Урок №16. GitOps и инструменты поставки](doc/lesson-16-kubernetes-gitops.md)
 
 [Урок №22. CSI. Обзор подсистем хранения данных в Kubernetes](doc/lesson-22-kubernetes-storage.md)
+
+[Урок №23. Отладка и тестирование в Kubernetes](doc/lesson-23-kubernetes-debug.md)

--- a/doc/lesson-23-kubernetes-debug.md
+++ b/doc/lesson-23-kubernetes-debug.md
@@ -1,0 +1,275 @@
+# Отладка и тестирование в Kubernetes
+
+## Kubectl-debug
+
+- Установка kubectl-debug
+
+    ```bash
+    export PLUGIN_VERSION=0.1.1
+    # linux x86_64
+    $ curl -Lo kubectl-debug.tar.gz https://github.com/aylei/kubectl-debug/releases/download/v${PLUGIN_VERSION}/kubectl-debug_${PLUGIN_VERSION}_linux_amd64.tar.gz
+    $ tar -zxvf kubectl-debug.tar.gz kubectl-debug
+    $ sudo mv kubectl-debug /usr/local/bin/
+    $ kubectl-debug --version
+    
+    debug version v0.0.0-master+$Format:%h$
+    ```
+
+- Установка kubectl-debug DaemonSet  
+
+    Скачать манифест
+
+    ```bash
+    wget https://raw.githubusercontent.com/aylei/kubectl-debug/dd7e4965e4ae5c4f53e6cf9fd17acc964274ca5c/scripts/agent_daemonset.yml
+    ```
+
+    Исправить версию API
+
+    Установить
+
+    ```bash
+    kubectl apply -f strace/agent_daemonset.yml
+    ```
+
+- Проверка strace
+
+    Создать Pod с nginx: kubernetes-debug/strace/test-pod.yaml
+
+    Установить его:
+
+    ```bash
+    kubectl apply -f strace/test-pod.yaml
+    ```
+
+    Запустить debug
+
+    ```bash
+    kubectl-debug testpod
+    ```
+
+    Запустить strace
+
+    ```bash
+    strace: attach: ptrace(PTRACE_SEIZE, 1): Operation not permitted
+    ```
+
+    Нужная capability не в версии `aylei/debug-agent:0.0.1`, а в версии `aylei/debug-agent:v0.1.1`.
+    Необходимо изменить версию docker image и переустановить DaemonSet.
+    Вообще говоря, его проще поставить из официальной документации.
+
+    После этого запустить strace
+
+    ```bash
+    $ kubectl-debug testpod
+
+    strace -c -p1
+    strace: Process 1 attached
+    ```
+
+## iptables-tailer
+
+Основной кейс - сообщить разработчикам сервисов о проблемах с NetworkPolicy.
+
+- Установка netperf-operator
+
+    Это Kubernetes-оператор, который позволяет запускать тесты пропускной
+способности сети между нодами кластера
+
+    ```bash
+    kubectl apply -f kit/deploy/crd.yaml
+    kubectl apply -f kit/deploy/rbac.yaml
+    kubectl apply -f kit/deploy/operator.yaml
+    kubectl apply -f kit/deploy/cr.yaml
+    ```
+
+    Проверка
+
+    ```bash
+    $ kubectl describe netperf.app.example.com/example
+
+    Name:         example
+    Namespace:    default
+    Labels:       <none>
+    Annotations:  API Version:  app.example.com/v1alpha1
+    Kind:         Netperf
+    Metadata:
+    Creation Timestamp:  2020-07-29T08:27:56Z
+    Generation:          4
+    Resource Version:    24623
+    Self Link:           /apis/app.example.com/v1alpha1/namespaces/default/netperfs/example
+    UID:                 38c8a232-4425-4398-a910-1f3dbdd28842
+    Spec:
+    Client Node:  
+    Server Node:  
+    Status:
+    Client Pod:          netperf-client-1f3dbdd28842
+    Server Pod:          netperf-server-1f3dbdd28842
+    Speed Bits Per Sec:  7785.21
+    Status:              Done
+    Events:                <none>
+    ```
+
+    Должно быть выведено `Status: Done` и `Speed Bits Per Sec:`.
+
+- Добавление сетевой политики calico.
+
+    ```bash
+    kubectl apply -f kit/networkpolicy.yaml
+    ```
+
+- Надо перезапустить netperf-тест cr.yaml
+
+    ```bash
+    kubectl delete -f kit/deploy/cr.yaml 
+    kubectl apply -f kit/deploy/cr.yaml
+    ```
+- Проверка теста еще раз
+
+    ```bash
+    $ kubectl describe netperf.app.example.com/example
+
+    Name:         example
+    Namespace:    default
+    Labels:       <none>
+    Annotations:  API Version:  app.example.com/v1alpha1
+    Kind:         Netperf
+    Metadata:
+    Creation Timestamp:  2020-07-29T08:38:09Z
+    Generation:          3
+    Resource Version:    27272
+    Self Link:           /apis/app.example.com/v1alpha1/namespaces/default/netperfs/example
+    UID:                 e533cfdf-3a45-4f65-ad71-8f9a87097dec
+    Spec:
+    Client Node:  
+    Server Node:  
+    Status:
+    Client Pod:          netperf-client-8f9a87097dec
+    Server Pod:          netperf-server-8f9a87097dec
+    Speed Bits Per Sec:  0
+    Status:              Started test
+    Events:                <none>
+    ```
+
+    Видим `Status: Started test`. В нашей сетевой политике есть ошибка.
+
+- Проверка, что в логах ноды есть сообщения об отброшенных пакетах
+
+    ```bash
+    # Зайти по SSH на node
+    gcloud compute ssh gke-cluster-1-default-pool-a68cb8d6-1kjh --zone us-east1-b
+
+    # Выполнить команды
+    sudo iptables --list -nv | grep DROP
+    sudo iptables --list -nv | grep LOG
+    journalctl -k | grep calico
+    ```
+
+- Установка iptables-tailer
+
+    Документация по установке: https://github.com/box/kube-iptables-tailer
+
+    Надо взять [DaemonSet](https://github.com/express42/otus-platform-snippets/blob/master/Module-03/Debugging/iptables-tailer.yaml). 
+    В нем должно быть `value: "calico-packet:"`
+    Переменная:
+
+    ```yaml
+    - name: "JOURNAL_DIRECTORY"
+      value: "/var/log/journal"
+    ``` 
+
+    Добавить к нему serviceaccount, clusterrole, clusterrolebinfing
+
+
+    ```bash
+    kubectl apply -f kit/kit-serviceaccount.yaml
+    kubectl apply -f kit/kit-clusterrole.yaml
+    kubectl apply -f kit/kit-clusterrolebinding.yaml
+    kubectl apply -f kit/iptables-tailer.yaml
+    ```
+    
+    Перезапустить netperf-тест
+
+    ```bash
+    kubectl delete -f kit/deploy/cr.yaml 
+    kubectl apply -f kit/deploy/cr.yaml
+    ```
+
+    Проверка теста еще раз
+
+    ```bash
+    $ kubectl describe netperf.app.example.com/example
+
+    Name:         netperf-server-a5c3f74c693e
+    Namespace:    default
+    Priority:     0
+    Node:         gke-cluster-1-default-pool-a68cb8d6-1kjh/10.142.0.3
+    Start Time:   Wed, 29 Jul 2020 12:33:48 +0300
+    Labels:       app=netperf-operator
+                netperf-type=server
+    Annotations:  cni.projectcalico.org/podIP: 10.8.1.11/32
+                kubernetes.io/limit-ranger: LimitRanger plugin set: cpu request for container netperf-server-a5c3f74c693e
+    Status:       Running
+    IP:           10.8.1.11
+    IPs:
+    IP:           10.8.1.11
+    Controlled By:  Netperf/example
+    Containers:
+    netperf-server-a5c3f74c693e:
+        Container ID:   docker://353ff0dc1e8518ca4f2f05bdecada75cc1019f8bbb2b0c6a3df05d7af3976c7d
+        Image:          tailoredcloud/netperf:v2.7
+        Image ID:       docker-pullable://tailoredcloud/netperf@sha256:0361f1254cfea87ff17fc1bd8eda95f939f99429856f766db3340c8cdfed1cf1
+        Port:           <none>
+        Host Port:      <none>
+        State:          Running
+        Started:      Wed, 29 Jul 2020 12:33:49 +0300
+        Ready:          True
+        Restart Count:  0
+        Requests:
+        cpu:        100m
+        Environment:  <none>
+        Mounts:
+        /var/run/secrets/kubernetes.io/serviceaccount from default-token-r9lbz (ro)
+    Conditions:
+    Type              Status
+    Initialized       True 
+    Ready             True 
+    ContainersReady   True 
+    PodScheduled      True 
+    Volumes:
+    default-token-r9lbz:
+        Type:        Secret (a volume populated by a Secret)
+        SecretName:  default-token-r9lbz
+        Optional:    false
+    QoS Class:       Burstable
+    Node-Selectors:  <none>
+    Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
+                    node.kubernetes.io/unreachable:NoExecute for 300s
+    Events:
+    Type     Reason      Age   From                                               Message
+    ----     ------      ----  ----                                               -------
+    Normal   Scheduled   16s   default-scheduler                                  Successfully assigned default/netperf-server-a5c3f74c693e to gke-cluster-1-default-pool-a68cb8d6-1kjh
+    Normal   Pulled      15s   kubelet, gke-cluster-1-default-pool-a68cb8d6-1kjh  Container image "tailoredcloud/netperf:v2.7" already present on machine
+    Normal   Created     15s   kubelet, gke-cluster-1-default-pool-a68cb8d6-1kjh  Created container netperf-server-a5c3f74c693e
+    Normal   Started     15s   kubelet, gke-cluster-1-default-pool-a68cb8d6-1kjh  Started container netperf-server-a5c3f74c693e
+    Warning  PacketDrop  13s   kube-iptables-tailer                               Packet dropped when receiving traffic from 10.8.2.8
+    ```
+
+    Есть запись c `Reason = PacketDrop`
+
+- Для того, чтобы в логе отображались имена Pod надо в `kubernetes-debug/kit/iptables-tailer.yaml` добавить переменную
+
+    ```yaml
+    - name: "POD_IDENTIFIER"
+      value: "name"
+    ```
+
+    Тогда получим вот такой вывод:
+
+    ```bash
+    $ kubectl describe netperf.app.example.com/example
+
+    Events:
+    Type     Reason      Age    From                                               Message
+    ----     ------      ----   ----                                               -------
+    Warning  PacketDrop  40s    kube-iptables-tailer                               Packet dropped when receiving traffic from netperf-client-a5c3f74c693e (10.8.2.8)
+    ```

--- a/kubernetes-debug/kit/deploy/cr-nodes.yaml
+++ b/kubernetes-debug/kit/deploy/cr-nodes.yaml
@@ -1,0 +1,7 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"
+spec:
+  serverNode: "minikube"
+  clientNode: "minikube"

--- a/kubernetes-debug/kit/deploy/cr.yaml
+++ b/kubernetes-debug/kit/deploy/cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"

--- a/kubernetes-debug/kit/deploy/crd.yaml
+++ b/kubernetes-debug/kit/deploy/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: netperfs.app.example.com
+spec:
+  group: app.example.com
+  names:
+    kind: Netperf
+    listKind: NetperfList
+    plural: netperfs
+    singular: netperf
+  scope: Namespaced
+  version: v1alpha1

--- a/kubernetes-debug/kit/deploy/operator.yaml
+++ b/kubernetes-debug/kit/deploy/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: netperf-operator
+  template:
+    metadata:
+      labels:
+        name: netperf-operator
+    spec:
+      containers:
+        - name: netperf-operator
+          image: tailoredcloud/netperf-operator:v0.1.1-742a3e1
+          command:
+          - netperf-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes-debug/kit/deploy/rbac.yaml
+++ b/kubernetes-debug/kit/deploy/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netperf-operator
+rules:
+- apiGroups:
+  - app.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-netperf-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: netperf-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/iptables-tailer.yaml
+++ b/kubernetes-debug/kit/iptables-tailer.yaml
@@ -1,0 +1,45 @@
+---
+  apiVersion: "apps/v1"
+  kind: "DaemonSet"
+  metadata:
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec:
+    selector:
+      matchLabels:
+        app: "kube-iptables-tailer"
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec:
+        serviceAccountName: kit
+        containers:
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+              - "--log_dir=/my-service-logs" # change the output directory of service logs
+              - "--v=4" # enable V-leveled logging at this level
+            env:
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+              - name: "POD_IDENTIFIER"
+                value: "name"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            image: "virtualshuric/kube-iptables-tailer:8d4296a"
+            volumeMounts:
+              - name: "iptables-logs"
+                mountPath: "/var/log"
+                readOnly: true
+              - name: "service-logs"
+                mountPath: "/my-service-logs"
+
+        volumes:
+          - name: "iptables-logs"
+            hostPath:
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+          - name: "service-logs"
+            emptyDir: {}

--- a/kubernetes-debug/kit/kit-clusterrole.yaml
+++ b/kubernetes-debug/kit/kit-clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kit
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - 'pods'
+  verbs:
+  - 'get'
+  - 'watch'
+  - 'list'
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - 'update'
+  - 'patch'
+  - 'create'

--- a/kubernetes-debug/kit/kit-clusterrolebinding.yaml
+++ b/kubernetes-debug/kit/kit-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kit
+subjects:
+- kind: ServiceAccount
+  name: kit
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: kit
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/kit-serviceaccount.yaml
+++ b/kubernetes-debug/kit/kit-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kit
+  namespace: kube-system

--- a/kubernetes-debug/kit/networkpolicy.yaml
+++ b/kubernetes-debug/kit/networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress: 
+    - action: Allow
+      source:
+        selector: netperf-role == "netperf-client"
+        #selector: app == "netperf-operator"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        selector: netperf-role == "netperf-client"
+        #selector: app == "netperf-operator"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/strace/agent_daemonset.yml
+++ b/kubernetes-debug/strace/agent_daemonset.yml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: debug-agent
+  name: debug-agent
+spec:
+  selector:
+    matchLabels:
+      app: debug-agent
+  template:
+    metadata:
+      labels:
+        app: debug-agent
+    spec:
+      containers:
+      - image: aylei/debug-agent:v0.1.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10027
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: debug-agent
+        ports:
+        - containerPort: 10027
+          hostPort: 10027
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: docker
+          mountPath: "/var/run/docker.sock"
+      hostNetwork: true
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate

--- a/kubernetes-debug/strace/test-pod.yaml
+++ b/kubernetes-debug/strace/test-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: testpod
+  name: testpod
+spec:
+  containers:
+  - image: nginx:1.19.1
+    name: testpod


### PR DESCRIPTION
# Выполнено ДЗ №23

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:

### Kubectl-debug

- Установка kubectl-debug

- Установка kubectl-debug DaemonSet  

- Проверка strace

### iptables-tailer

- Установка netperf-operator

- Добавление сетевой политики calico.

- Надо перезапустить netperf-тест cr.yaml

- Проверка теста еще раз

- Проверка, что в логах ноды есть сообщения об отброшенных пакетах

- Установка iptables-tailer

- Для того, чтобы в логе отображались имена Pod надо в `kubernetes-debug/kit/iptables-tailer.yaml` добавить переменную `POD_IDENTIFIER`

## Как запустить проект:
```bash
    kubectl apply -f strace/agent_daemonset.yml
```
```bash
    kubectl apply -f strace/test-pod.yaml
```

```bash
    kubectl-debug testpod
```

## Как проверить работоспособность:
Должен отображаться strace

## PR checklist:
 - [x] Выставлен label с темой домашнего задания